### PR TITLE
Add overwrite option to ome_zarr.add_table

### DIFF
--- a/src/fractal_cellpose_sam_task/cellpose_sam_segmentation_task.py
+++ b/src/fractal_cellpose_sam_task/cellpose_sam_segmentation_task.py
@@ -346,7 +346,11 @@ def cellpose_sam_segmentation_task(
     if isinstance(create_masking_roi_table, CreateMaskingRoiTable):
         table_name = create_masking_roi_table.get_table_name(label_name=label_name)
         masking_roi_table = label.build_masking_roi_table()
-        ome_zarr.add_table(name=table_name, table=masking_roi_table)
+        ome_zarr.add_table(
+            name=table_name, 
+            table=masking_roi_table, 
+            overwrite=overwrite
+        )
     return None
 
 


### PR DESCRIPTION
Currently, rerunning a Cellpose SAM task that generates a masking ROI table fails with an ngio error about table overwriting:

```
ngio.utils._errors.NgioValueError: Table 'organoids_ROI_table' already exists in the group. Use overwrite=True to replace it.
```

I suggest we make the masking ROI table adopt the overall overwrite setting to fix that.